### PR TITLE
msys2_installation.rb: ensure the mingw path is lowercase

### DIFF
--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -76,7 +76,7 @@ module Build # Use for: Build, Runtime
     end
 
     def mingw_bin_path(mingwarch=nil)
-      backslachs( File.join(msys_path, mingwarch || msystem, "bin") )
+      backslachs( File.join(msys_path, mingwarch || msystem.downcase, "bin") )
     end
 
     def mingw_prefix


### PR DESCRIPTION
The 'MSYSTEM' environment variable stores the mingw system in uppercase, but its value is used to create the path to mingw binaries and must be downcased there. It should solve the problem #44.