### PR TITLE
Fix typo in msys2 component

### DIFF
--- a/lib/ruby_installer/runtime/components/01_msys2.rb
+++ b/lib/ruby_installer/runtime/components/01_msys2.rb
@@ -14,7 +14,7 @@ class Msys2 < Base
       puts green("already installed")
       false
     rescue Msys2Installation::MsysNotFound
-      puts red("unavaiable")
+      puts red("unavailable")
       true
     end
   end


### PR DESCRIPTION
Fixes a ~critical bug~ minor spelling issue in msys2 error logging.