### PR TITLE
Cygwin

### DIFF
--- a/resources/files/rbreadline.rb
+++ b/resources/files/rbreadline.rb
@@ -2428,7 +2428,7 @@ module RbReadline
                    ss.scan(/\d\d/).to_i(16).chr
                  when '0'..'7'
                    ss.pos -= 1
-                   ss.scan(/\d\d\d/).to_i(8).chr
+                   ss.scan(/\d{1,3}/).to_i(8).chr
                  else
                    char
                  end


### PR DESCRIPTION
I have downloaded RubyInstaller

I also prefer to use Cygwin over MSYS2

This command works as expected:

~~~
$ echo 2 + 2 | irb
Switch to inspect mode.
2 + 2
4
~~~

However this command fails:

~~~
$ irb
C:/ruby25-x64/lib/ruby/site_ruby/rbreadline.rb:2431:in `to_i': wrong number of
arguments (given 1, expected 0) (ArgumentError)
~~~

looks like the problem is here:

https://github.com/oneclick/rubyinstaller2/blob/0710e14c60477e0ef66fbdc84eec6c5b11641ed0/resources/files/rbreadline.rb#L2429-L2431

if I add a `p` in the right spot I get this:

~~~
"\\33[1;5C"
~~~

so the regex is looking for 3 numbers, probably `033`, but only 2 are being
provided. as this is an escape code i figure disabling color with ruby would
solve the problem, but i didnt see an option to do that. octal support 1, 2 and
3 digits:

~~~sh
$ printf '\7\07\007' | od -t cx1
0000000  \a  \a  \a
         07  07  07
~~~

so perhaps a better pattern would be:

~~~rb
/\d{1,3}/
~~~