### PR TITLE
Detect scoop-managed msys2

### DIFF
--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -65,6 +65,9 @@ module Build # Use for: Build, Runtime
         yield path
       end
 
+      # If msys2 is installed by scoop package manager
+      yield IO.popen(["scoop", "prefix", "msys2"], &:read).strip rescue StandardError
+
       raise MsysNotFound, "MSYS2 could not be found"
     end
 


### PR DESCRIPTION
[Scoop](https://github.com/lukesampson/scoop) is a command-line installer for Windows like chocolatey.

The scoop-managed msys2 could be detected by `scoop prefix msys2` that returns the path to the specified app.

Fix https://github.com/ScoopInstaller/Main/issues/271
