### PR TITLE
Fix URLs in the Installer WizardForm.FinishedPage

### DIFF
--- a/recipes/installer-inno/ri_gui.iss
+++ b/recipes/installer-inno/ri_gui.iss
@@ -250,7 +250,7 @@ begin
   URLText.Top := TmpLabel.Top;
   URLText.Left := TmpLabel.Left + TmpLabel.Width + ScaleX(4);
   URLText.AutoSize := True;
-  URLText.Caption := 'http://rubyinstaller.org';
+  URLText.Caption := 'https://rubyinstaller.org';
   URLText.Cursor := crHand;
   URLText.Font.Color := clBlue;
   URLText.OnClick := @URLText_OnClick;
@@ -267,7 +267,7 @@ begin
   URLText.Top := TmpLabel.Top;
   URLText.Left := TmpLabel.Left + TmpLabel.Width + ScaleX(4);
   URLText.AutoSize := True;
-  URLText.Caption := 'http://groups.google.com/group/rubyinstaller';
+  URLText.Caption := 'https://groups.google.com/group/rubyinstaller';
   URLText.Cursor := crHand;
   URLText.Font.Color := clBlue;
   URLText.OnClick := @URLText_OnClick;
@@ -284,7 +284,7 @@ begin
   URLText.Top := TmpLabel.Top;
   URLText.Left := TmpLabel.Left + TmpLabel.Width + ScaleX(4);
   URLText.AutoSize := True;
-  URLText.Caption := 'https://wiki.github.com/larskanis/rubyinstaller2';
+  URLText.Caption := 'https://github.com/oneclick/rubyinstaller2/wiki';
   URLText.Cursor := crHand;
   URLText.Font.Color := clBlue;
   URLText.OnClick := @URLText_OnClick;


### PR DESCRIPTION
[1] As mentioned by @larskanis at http://disq.us/p/2ee06yv - the URL for the wiki in the GUI is incorrect. This just changes the URLText to the correct link.
[2] Also, changes the TextURL for RubyInstaller.org & Google Groups to https instead of http