### PR TITLE
CI: Update build-ruby versions for Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,22 +13,22 @@ jobs:
         include:
         - target_ruby: "3.0.2"
           arch: "x86-msvcrt"
-          build_ruby: "2.7.3/x64"
-          run_mri_spec: ruby_3_0
+          build_ruby: "2.7.4/x64"
+          run_ruby_spec: true
 
         - target_ruby: "3.0.2"
           arch: "x64-msvcrt"
-          build_ruby: "2.7.3/x64"
-          run_mri_spec: ruby_3_0
+          build_ruby: "2.7.4/x64"
+          run_ruby_spec: true
 
         - target_ruby: "2.7.4"
           arch: "x86-msvcrt"
-          build_ruby: "2.6.7/x64"
+          build_ruby: "2.6.8/x64"
           run_ruby_spec: true
 
         - target_ruby: "2.7.4"
           arch: "x64-msvcrt"
-          build_ruby: "2.6.7/x64"
+          build_ruby: "2.6.8/x64"
           run_ruby_spec: true
 
         - target_ruby: "2.6.8"
@@ -43,17 +43,17 @@ jobs:
 
         - target_ruby: "head"
           arch: "x64-ucrt"
-          build_ruby: "2.6.7/x64"
+          build_ruby: "2.6.8/x64"
           run_mri_spec: master
 
         - target_ruby: "head"
           arch: "x64-msvcrt"
-          build_ruby: "2.6.7/x64"
+          build_ruby: "2.6.8/x64"
           run_mri_spec: master
 
         - target_ruby: "head"
           arch: "x86-msvcrt"
-          build_ruby: "2.6.7/x64"
+          build_ruby: "2.6.8/x64"
           run_mri_spec: master
 
     runs-on: windows-latest


### PR DESCRIPTION
Also use latest ruby-spec for ruby-3.0.2, since ruby-spec promise to succeed on latest stable ruby releases.