### PR TITLE
Use HTTPS for downloading MSYS2

### DIFF
--- a/lib/ruby_installer/build/components/01_msys2.rb
+++ b/lib/ruby_installer/build/components/01_msys2.rb
@@ -43,7 +43,7 @@ class Msys2 < Base
   private
 
   MSYS2_VERSION = ENV['MSYS2_VERSION'] || "20190524"
-  MSYS2_URI = "http://repo.msys2.org/distrib/<arch>/msys2-<arch>-#{MSYS2_VERSION}.exe"
+  MSYS2_URI = "https://repo.msys2.org/distrib/<arch>/msys2-<arch>-#{MSYS2_VERSION}.exe"
 
   MSYS2_I686_SHA256 = "c5a1881f7ac5a0449fe9b30d3140111a88072727f510c4a66bfa905f8c78e839"
   MSYS2_X86_64_SHA256 = "2dacadcc70cc122054e60914cbc6b689f685bef5713915a90f4185dd9da7954e"


### PR DESCRIPTION
It appears https://repo.msys2.org is working with a Let's Encrypt cert. 

```
D:\>ridk install
 _____       _           _____           _        _ _         ___
|  __ \     | |         |_   _|         | |      | | |       |__ \
| |__) |   _| |__  _   _  | |  _ __  ___| |_ __ _| | | ___ _ __ ) |
|  _  / | | | '_ \| | | | | | | '_ \/ __| __/ _` | | |/ _ \ '__/ /
| | \ \ |_| | |_) | |_| |_| |_| | | \__ \ || (_| | | |  __/ | / /_
|_|  \_\__,_|_.__/ \__, |_____|_| |_|___/\__\__,_|_|_|\___|_||____|
                    __/ |           _
                   |___/          _|_ _  __   | | o __  _| _     _
                                   | (_) |    |^| | | |(_|(_)\^/_>

   1 - MSYS2 base installation
   2 - MSYS2 system update (optional)
   3 - MSYS2 and MINGW development toolchain

Which components shall be installed? If unsure press ENTER [1,3] 1

MSYS2 seems to be unavailable
Download http://repo.msys2.org/distrib/x86_64/msys2-x86_64-20190524.exe
  to C:\Users\**************\AppData\Local\Temp/msys2-x86_64-20190524.exe
Downloading msys2-x86_64-20190524.exe (148%)
Verify integrity of msys2-x86_64-20190524.exe ... Failed
```