### PR TITLE
Fix recent release dates in changelogs

### DIFF
--- a/CHANGELOG-2.5.md
+++ b/CHANGELOG-2.5.md
@@ -1,4 +1,4 @@
-## RubyInstaller-2.5.9-1 - 2020-04-19
+## RubyInstaller-2.5.9-1 - 2021-04-19
 
 ### Added
 - Add more environment variables needed for configure scripts: MSYSTEM_PREFIX, MSYSTEM_CARCH, MSYSTEM_CHOST, MINGW_CHOST, MINGW_PREFIX

--- a/CHANGELOG-2.6.md
+++ b/CHANGELOG-2.6.md
@@ -9,7 +9,7 @@
 - Update of the SSL CA certificate list.
 
 
-## RubyInstaller-2.6.8-1 - 2020-07-09
+## RubyInstaller-2.6.8-1 - 2021-07-09
 
 ### Added
 - Enable ruby to support path length >260 characters.
@@ -23,7 +23,7 @@
 - Update bundled gpg keyring file for pacman to support new MSYS2 package signatures.
 
 
-## RubyInstaller-2.6.7-1 - 2020-04-19
+## RubyInstaller-2.6.7-1 - 2021-04-19
 
 ### Added
 - Add more environment variables needed for configure scripts: MSYSTEM_PREFIX, MSYSTEM_CARCH, MSYSTEM_CHOST, MINGW_CHOST, MINGW_PREFIX

--- a/CHANGELOG-2.7.md
+++ b/CHANGELOG-2.7.md
@@ -9,7 +9,7 @@
 - Update of the SSL CA certificate list.
 
 
-## RubyInstaller-2.7.4-1 - 2020-07-09
+## RubyInstaller-2.7.4-1 - 2021-07-09
 
 ### Added
 - Enable ruby to support path length >260 characters.
@@ -24,7 +24,7 @@
 - Update bundled gpg keyring file for pacman to support new MSYS2 package signatures.
 
 
-## RubyInstaller-2.7.3-1 - 2020-04-19
+## RubyInstaller-2.7.3-1 - 2021-04-19
 
 ### Added
 - Add more environment variables needed for configure scripts: MSYSTEM_PREFIX, MSYSTEM_CARCH, MSYSTEM_CHOST, MINGW_CHOST, MINGW_PREFIX

--- a/CHANGELOG-3.0.md
+++ b/CHANGELOG-3.0.md
@@ -9,7 +9,7 @@
 - Update of the SSL CA certificate list.
 
 
-## RubyInstaller-3.0.2-1 - 2020-07-09
+## RubyInstaller-3.0.2-1 - 2021-07-09
 
 ### Added
 - Enable ruby to support path length >260 characters.
@@ -24,7 +24,7 @@
 - Update bundled gpg keyring file for pacman to support new MSYS2 package signatures.
 
 
-## RubyInstaller-3.0.1-1 - 2020-04-19
+## RubyInstaller-3.0.1-1 - 2021-04-19
 
 ### Added
 - Add more environment variables needed for configure scripts: MSYSTEM_PREFIX, MSYSTEM_CARCH, MSYSTEM_CHOST, MINGW_CHOST, MINGW_PREFIX


### PR DESCRIPTION
Cleans up a few typos. A few of the recent entries on the releases page have incorrect dates too.

Thanks for everything you do in this project!