### PR TITLE
Fix a runtime error when running cgi in WEBrick http server.

### DIFF
--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -75,7 +75,7 @@ module Build # Use for: Build, Runtime
       rescue Win32::Registry::Error
       end
 
-      ENV['PATH'].split(";").each do |path|
+      ENV['PATH'] && ENV['PATH'].split(";").each do |path|
         # If /path/to/msys64 is in the PATH (e.g. Chocolatey)
         yield path
       end


### PR DESCRIPTION
I use Ruby 27 2.7.4-1 x64 msvcrt and running WEBrick.
When run the CGI program, I got a runtime error in msys2_installation.rb.

error message is here.
```
C:/Ruby27-x64/lib/ruby/site_ruby/2.7.0/ruby_installer/runtime/msys2_installation.rb:76:in `iterate_msys_paths': undefined method `split' for nil:NilClass (NoMethodError)
```

When running the CGI program, the ENV environment variables were rewritten to the values for CGI.

e.g.
```
{"GATEWAY_INTERFACE"=>"CGI/1.1", "HTTP_ACCEPT"=>"text/html,application..."}
```
