### PR TITLE
Workaround for `ridk use` raising NoMethodError.

### DIFF
--- a/resources/files/ridk_use/ridk_use.rb
+++ b/resources/files/ridk_use/ridk_use.rb
@@ -143,7 +143,11 @@ def switch_ruby_per_cmd(rubypath, rubies, ps1)
 
   if ps1
     vars.map do |key, val|
-      "$env:#{key}=\"#{val.gsub('"', '`"')}\""
+      if val != nil
+        "$env:#{key}=\"#{val.gsub('"', '`"')}\""
+      else
+        "$env:#{key}=\"\""
+      end
     end.join(";")
   else
     vars.map do |key, val|


### PR DESCRIPTION
Avoid method call if the `val` is `nil`.

### Before

![before](https://user-images.githubusercontent.com/1663225/176992713-c36827d0-7d63-4857-9817-0eacad3817b2.png)

### After

![after](https://user-images.githubusercontent.com/1663225/176992721-44b6287f-1e19-456e-a5ee-bd774644555d.png)
