### PR TITLE
Remove space in regex from msys2_installation.rb

### DIFF
--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -71,7 +71,7 @@ module Build # Use for: Build, Runtime
             reg.each_key do |subkey|
               subreg = reg.open(subkey)
               begin
-                if subreg['DisplayName'] =~ /^MSYS2 / && File.directory?(il=subreg['InstallLocation'])
+                if subreg['DisplayName'] =~ /^MSYS2/ && File.directory?(il=subreg['InstallLocation'])
                   yield il
                 end
               rescue Encoding::InvalidByteSequenceError, Win32::Registry::Error


### PR DESCRIPTION
The space does not look good because I have the value in `HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Uninstall\{a93ceac8-6f93-47bd-adbf-d1cb0953d6cf}\DisplayName` only `MSYS2`, not `MSYS2 `.