### PR TITLE
ensure path caused failure in skip-case

### DIFF
--- a/test/test_win32-registry.rb
+++ b/test/test_win32-registry.rb
@@ -13,25 +13,24 @@ class TestWin32Registry < Minitest::Test
 
     old_cp = `chcp`[/\d+/]
     `chcp 850`
-    require "win32/registry"
-    keys = []
-    Win32::Registry::HKEY_CURRENT_USER.create(backslachs(TEST_REGISTRY_KEY)) do |reg|
-      reg.create("abc EUR")
-      reg.create("abc €")
-      reg.each_key do |subkey|
-        keys << subkey
-      end
-    end
-    
-    assert_equal [Encoding::UTF_8] * 2, keys.map(&:encoding)
-    assert_equal ["abc EUR", "abc €"], keys
-  ensure
     begin
+      require "win32/registry"
+      keys = []
+      Win32::Registry::HKEY_CURRENT_USER.create(backslachs(TEST_REGISTRY_KEY)) do |reg|
+        reg.create("abc EUR")
+        reg.create("abc €")
+        reg.each_key do |subkey|
+          keys << subkey
+        end
+      end
+      
+      assert_equal [Encoding::UTF_8] * 2, keys.map(&:encoding)
+      assert_equal ["abc EUR", "abc €"], keys
+    ensure
       Win32::Registry::HKEY_CURRENT_USER.open(backslachs(File.dirname(TEST_REGISTRY_KEY))) do |reg|
         reg.delete_key File.basename(TEST_REGISTRY_KEY), true
       end
-    rescue Win32::Registry::Error
+      `chcp #{old_cp}`
     end
-    `chcp #{old_cp}`
   end
 end


### PR DESCRIPTION
So do ensure code only after chcp