### PR TITLE
Avoid method redefinition warning

### DIFF
--- a/resources/files/operating_system.rb
+++ b/resources/files/operating_system.rb
@@ -6,12 +6,19 @@ begin
   File.unlink(checkfile) rescue nil # Raises ENOENT sometimes
 rescue Errno::EACCES
   warn_per_user = true
-  # Set default options for the gem command
-  def Gem.operating_system_defaults
-    defaults = ["--install-dir", Gem.user_dir]
-    bindir = File.join(Gem.user_home, 'AppData/Local/Microsoft/WindowsApps')
-    defaults += ["--bindir", bindir] if File.directory?(bindir)
-    { 'gem' => defaults }
+  module Gem
+    class << self
+      # Hack to prevent method redefinition warning
+      alias_method :operating_system_defaults, :operating_system_defaults
+
+      # Set default options for the gem command
+      def operating_system_defaults
+        defaults = ["--install-dir", Gem.user_dir]
+        bindir = File.join(Gem.user_home, 'AppData/Local/Microsoft/WindowsApps')
+        defaults += ["--bindir", bindir] if File.directory?(bindir)
+        { 'gem' => defaults }
+      end
+    end
   end
   # Set default options for the bundle command
   ENV['GEM_HOME'] ||= Gem.user_dir


### PR DESCRIPTION
We're getting some [test failures ](https://github.com/rubygems/rubygems/actions/runs/7708963464/job/21009146956?pr=7438) in rubygems because we run `gem` commands in verbose mode, in situations where the default GEM_HOME is not writable.

I'm not sure of the root cause (why GEM_HOME is not writable), since it only happens sporadically so I guess some other specs may be leaking permission changes or something. Also we could probably switch those to run in non verbose mode, or manually skip the warnings. But it seems best to not let the warning be printed in the first place, since that's exactly what's intended here.

This PR is a hack to achieve that.