### PR TITLE
Avoid crash even if a registry key incldues inconvertible characters

### DIFF
--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -82,6 +82,8 @@ module Build # Use for: Build, Runtime
                 # Ignore entries without valid installer data or broken character encoding
               end
             end
+          rescue Encoding::InvalidByteSequenceError, Encoding::UndefinedConversionError
+            # Avoid crash even if subkey includes inconvertible characters to internal encoding
           end
         rescue Win32::Registry::Error
         end


### PR DESCRIPTION
When the registry key `SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall` contains inconvertible characters to internal encoding, `require rubygems` crashes. This patch avoids this issue.

Fixe #372