### PR TITLE
Move bundled OpenSSL related files to bin/lib subdirectory.

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -4,6 +4,7 @@
 - Update to ruby-3.2.4, see [release notes](https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-2-4-released/).
 - Update the SSL CA certificate list.
 - Update to OpenSSL-3.3.0. The Ruby API dosn't change.
+- Move bundled OpenSSL related files to bin/lib subdirectory so that legacy algorithms can be loaded through provider support. #365
 - Update the bundled MSYS2 keyring package.
 - Avoid crash even if a registry key incldues inconvertible characters
 - Avoid method redefinition warning in rubygems hook

--- a/CHANGELOG-3.3.md
+++ b/CHANGELOG-3.3.md
@@ -4,6 +4,7 @@
 - Update to ruby-3.3.1, see [release notes](https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-3-1-released/).
 - Update the SSL CA certificate list.
 - Update to OpenSSL-3.3.0. The Ruby API dosn't change.
+- Move bundled OpenSSL related files to bin/lib subdirectory so that legacy algorithms can be loaded through provider support. #365
 - Update the bundled MSYS2 keyring package.
 - Avoid crash even if a registry key incldues inconvertible characters
 - Avoid method redefinition warning in rubygems hook

--- a/recipes/sandbox/70-move-openssl-files-to-bin.rake
+++ b/recipes/sandbox/70-move-openssl-files-to-bin.rake
@@ -1,0 +1,22 @@
+# Move bundled OpenSSL related files to bin/lib subdirectory.
+# This is necessary because libcrypt.dll and libssl.dll are located in bin/ruby_builtin_dlls and they search other dlls in ../lib
+
+if package.rubyver2 >= "3.2"
+  osl_files = %w[
+    lib/engines-3/capi.dll
+    lib/engines-3/loader_attic.dll
+    lib/engines-3/padlock.dll
+    lib/ossl-modules/legacy.dll
+  ]
+
+  osl_files.each do |path|
+    # Add tasks to write the DLLs into the sub directory
+    destpath = File.join(sandboxdir, "bin", path)
+    file destpath => [File.join(unpackdirmgw, path), File.dirname(destpath)] do |t|
+      cp(t.prerequisites.first, t.name)
+    end
+
+    # Add the DLLs in the dependent files list to the subdirectory
+    self.sandboxfiles << destpath
+  end
+end

--- a/recipes/sandbox/rubyinstaller-3.2.4.files
+++ b/recipes/sandbox/rubyinstaller-3.2.4.files
@@ -28,10 +28,6 @@ bin/ruby.exe
 bin/rubyw.exe
 bin/zlib1.dll
 include/ruby-3.2.0
-lib/engines-3/capi.dll
-lib/engines-3/loader_attic.dll
-lib/engines-3/padlock.dll
-lib/ossl-modules/legacy.dll
 lib/pkgconfig/ruby-3.2.pc
 lib/ruby/3.2.0
 lib/ruby/gems/3.2.0

--- a/recipes/sandbox/rubyinstaller-3.3.1.files
+++ b/recipes/sandbox/rubyinstaller-3.3.1.files
@@ -28,10 +28,6 @@ bin/ruby.exe
 bin/rubyw.exe
 bin/zlib1.dll
 include/ruby-3.3.0
-lib/engines-3/capi.dll
-lib/engines-3/loader_attic.dll
-lib/engines-3/padlock.dll
-lib/ossl-modules/legacy.dll
 lib/pkgconfig/ruby-3.3.pc
 lib/ruby/3.3.0
 lib/ruby/gems/3.3.0

--- a/recipes/sandbox/rubyinstaller-head.files
+++ b/recipes/sandbox/rubyinstaller-head.files
@@ -28,10 +28,6 @@ bin/ruby.exe
 bin/rubyw.exe
 bin/zlib1.dll
 include/ruby-3.4.0+0
-lib/engines-3/capi.dll
-lib/engines-3/loader_attic.dll
-lib/engines-3/padlock.dll
-lib/ossl-modules/legacy.dll
 lib/pkgconfig/ruby-3.4.pc
 lib/ruby/3.4.0+0
 lib/ruby/gems/3.4.0+0

--- a/test/test_stdlib.rb
+++ b/test/test_stdlib.rb
@@ -77,4 +77,14 @@ class TestStdlib < Minitest::Test
         assert_match(/OpenSSL 3\./, OpenSSL::OPENSSL_LIBRARY_VERSION)
     end
   end
+
+  def test_openssl_provider
+    # ruby-3.2 has OpenSSL-3.x which supports provider API, but the ruby C-ext is too old there
+    return if RUBY_VERSION =~ /^2\.[34567]\.|^3\.[012]\./
+    require "openssl"
+
+    OpenSSL::Provider.load("legacy")
+    cipher = OpenSSL::Cipher.new("RC4")
+    assert_equal "RC4", cipher.name
+  end
 end


### PR DESCRIPTION
This is necessary because libcrypt.dll and libssl.dll are located in bin/ruby_builtin_dlls and they search other dlls in ../lib

Fixes #365