### PR TITLE
Set a single key in gemrc to allow appending

### DIFF
--- a/resources/files/operating_system.rb
+++ b/resources/files/operating_system.rb
@@ -65,7 +65,7 @@ begin
 # But do not delete this file as otherwise it could be hijacked by
 # another user in a multi-user environment.
 ---
-{}
+verbose: false
       EOT
     end
   end


### PR DESCRIPTION
The previous "{}" literal closed the root hash, so that appending text to the file doesn't work easily. But it's the only way to set an empty hash.
As a solution, we set a single key now.

This was raised in https://github.com/oneclick/rubyinstaller2/issues/388#issuecomment-2348393612