### PR TITLE
Fix pacman install within a parallel bundler install -jX

### DIFF
--- a/test/helper/testgem/Gemfile
+++ b/test/helper/testgem/Gemfile
@@ -1,2 +1,3 @@
 source "https://dummy-url.nonexit"
+gem "testgem2", "1.0.0"
 gem "testgem", "1.0.0"

--- a/test/helper/testgem/ext2/extconf2.rb
+++ b/test/helper/testgem/ext2/extconf2.rb
@@ -1,0 +1,8 @@
+require 'mkmf'
+
+message "checking for libidn2 package: "
+pkg = pkg_config('libidn2') || raise("pkg_config should find the config")
+message "#{pkg.inspect}\n"
+have_func('idn2_strerror') || raise("have_func should find the pkgconfig library")
+
+create_makefile("testgem2")

--- a/test/helper/testgem/ext2/testgem2.c
+++ b/test/helper/testgem/ext2/testgem2.c
@@ -1,0 +1,17 @@
+#include <sys/types.h>
+#include <stdio.h>
+#include <ruby.h>
+#include <idn2.h>
+
+static VALUE rb_idn2_strerror(VALUE self, VALUE errcode){
+    const char *res;
+    res = idn2_strerror(NUM2INT(errcode));
+    return res ? rb_str_new_cstr(res) : Qnil;
+}
+
+void
+Init_testgem2(void)
+{
+    VALUE lg = rb_define_class("Idn2", rb_cObject);
+    rb_define_singleton_method(lg, "idn2_strerror", rb_idn2_strerror, 1);
+}

--- a/test/helper/testgem/testgem2.gemspec
+++ b/test/helper/testgem/testgem2.gemspec
@@ -1,0 +1,15 @@
+Gem::Specification.new do |s|
+  s.name = 'testgem2'
+  s.version = '1.0.0'
+  s.author = 'Lars Kanis'
+  s.email = 'lars@greiz-reinsdorf.de'
+  s.homepage = 'https://github.com/larskanis/rubyinstaller2'
+  s.summary = 'RubyInstaller2 testgem'
+  s.description = 'A second gem to test gem installation with RubyInstaller2'
+  s.files = `git ls-files`.split("\n")
+  s.extensions << 'ext2/extconf2.rb'
+  s.license = 'BSD-3-Clause'
+  s.require_paths << 'lib'
+  s.required_ruby_version = '>= 2.1.0'
+  s.metadata['msys2_mingw_dependencies'] = 'libidn2 gcc>=8.0'
+end


### PR DESCRIPTION
pacman invocation must be serialized to avoid locking error.

Add a second gem using libidn2, so that two different libraries are requested and the test case fails if anyone isn't available after parallel pacman execution.

The test case requires bundler-2.6.x to trigger the failure due to https://github.com/rubygems/rubygems/pull/8248 .

Fixes #397