### PR TITLE
Reverse the junction/link to "ssl" dir

### DIFF
--- a/recipes/installer-inno/rubyinstaller.iss.erb
+++ b/recipes/installer-inno/rubyinstaller.iss.erb
@@ -133,7 +133,6 @@ Root: <%= regroot %>; Subkey: Software\Classes\<%= rubyname %>File\shell\open\co
 ; So use Innosetup to add described permissions and icacls to disable unwanted inheritance.
 [Dirs]
 Name: {app}; Permissions: creatorowner-full users-readexec admins-full
-Name: "{app}/<%= package.rubyver2 =~ /^3\.[23]$/ ? "bin/etc" : "lib/ruby/#{ package.rubylibver }/etc" %>"
 
 [Run]
 ; Set permissions on install directories
@@ -141,8 +140,8 @@ Filename: "icacls.exe"; Parameters: """{app}"" /inheritancelevel:r "; WorkingDir
 <% if with_msys %>
 Filename: "icacls.exe"; Parameters: """{app}\<%= package.msysdir %>\tmp"" /inheritancelevel:r /grant *S-1-5-32-545:(CI)(WD,AD,WEA,WA) /grant *S-1-3-0:(OI)(CI)(IO)(F) /grant *S-1-5-32-544:(OI)(CI)(F) /grant *S-1-5-32-545:(NP)(RX) "; WorkingDir: "{app}"; StatusMsg: "Changing MSYS2 /tmp Directory Permissions"; Flags: runhidden; Components: msys2
 <% end %>
-; Add link to SSL CA certs so that OpenSSL finds them based on the libssl.dll location
-Filename: "{cmd}"; Parameters: "/c mklink /j <%= package.rubyver2 =~ /^3\.[23]$/ ? "bin" : "lib\\ruby\\#{package.rubylibver}" %>\etc\ssl ssl"; WorkingDir: "{app}"; StatusMsg: "Add link to SSL CA certs"; Flags: runhidden
+; Add link to SSL CA certs. The destination depends on the libssl.dll location.
+Filename: "{cmd}"; Parameters: "/c mklink /j ssl <%= package.rubyver2 =~ /^3\.[23]$/ ? "bin" : "lib\\ruby\\#{package.rubylibver}" %>\etc\ssl"; WorkingDir: "{app}"; StatusMsg: "Add link to SSL CA certs"; Flags: runhidden
 
 [Icons]
 Name: {autoprograms}\{#InstallerName}\{cm:InteractiveRubyTitle}; Filename: {app}\bin\irb.<%= package.rubyver2 < '3.1' ? "cmd" : "bat" %>; IconFilename: {app}\bin\ruby.exe

--- a/recipes/sandbox/10-define-variables.rake
+++ b/recipes/sandbox/10-define-variables.rake
@@ -3,3 +3,11 @@ self.thisdir = "recipes/sandbox"
 self.sandboxdir = "#{thisdir}/#{package.packagenameverarch}"
 self.import_files = {}
 self.sandboxfiles = []
+self.ssl_dir = case
+  when package.rubyver2 < "3.2"
+    "ssl"
+  when package.rubyver2 < "3.4"
+    "bin/etc/ssl"
+  else
+    "lib/ruby/#{package.rubylibver}/etc/ssl"
+end

--- a/recipes/sandbox/20-define-import-files.rake
+++ b/recipes/sandbox/20-define-import-files.rake
@@ -10,8 +10,8 @@ self.import_files.merge!({
   "resources/files/setrbvars.cmd" => "bin/setrbvars.cmd",
   "resources/files/operating_system.rb" => "lib/ruby/#{package.rubylibver}/rubygems/defaults/operating_system.rb",
   "resources/icons/ruby-doc.ico" => "share/doc/ruby/html/images/ruby-doc.ico",
-  "resources/ssl/cacert.pem" => "ssl/cert.pem",
-  "resources/ssl/README-SSL.md" => "ssl/README-SSL.md",
-  "resources/ssl/c_rehash.rb" => "ssl/certs/c_rehash.rb",
+  "resources/ssl/cacert.pem" => "#{ssl_dir}/cert.pem",
+  "resources/ssl/README-SSL.md" => "#{ssl_dir}/README-SSL.md",
+  "resources/ssl/c_rehash.rb" => "#{ssl_dir}/certs/c_rehash.rb",
   "#{thisdir}/LICENSE.txt" => "LICENSE.txt",
 })

--- a/resources/ssl/README-SSL.md
+++ b/resources/ssl/README-SSL.md
@@ -9,6 +9,16 @@ New releases of the RubyInstaller2 update the CA list to the latest version at t
 `cert.pem` shouldn't be modified manually, because it will be overwritten by updates of RubyInstaller2.
 Instead add certificates as described below.
 
+Location of the bundled certificates
+------------------------------------
+The storage directory of the bundled certificates varies depending on the ruby version.
+Due to a junction created by the installer the certs can always be found in `<install-path>/ssl`.
+When using the 7z archive the link is not present, but the certificates are stored here:
+
+* ruby <= 3.1.x  :  `ssl`
+* ruby >= 3.2.x and <= 3.3.x  :  `bin/etc/ssl`
+* ruby >= 3.4.x  :  `lib/ruby/<ruby-version>/etc/ssl`
+
 Use of an alternative Ruby CA list
 -----------------------------
 


### PR DESCRIPTION
Now the certs are stored under `<ruby>/lib/...` and `<ruby>/ssl` is linked to this directory per innosetup installer.

Before this commit, the link was the other way around, but junctions can not be stored/restored in a 7z archive. This led to certs not found when 7z archive was used, like in ruby/setup-ruby.

Fixes #405