### PR TITLE
Exclude spec which is no longer applicable since json-2.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -261,7 +261,7 @@ jobs:
         ridk enable
         if (-not ([string]::IsNullOrWhiteSpace($env:run_mri_spec))) {
           git clone --depth 1 https://github.com/ruby/ruby -b $env:run_mri_spec &&
-          env --unset=RUBYOPT ruby -C ruby/spec/ruby ../mspec/bin/mspec -I../../tool/lib -j
+          env --unset=RUBYOPT ruby -C ruby/spec/ruby ../mspec/bin/mspec -I../../tool/lib -j  --exclude "CVE-2020-10663 is resisted by only creating custom objects if passed create_additions: true or using JSON.load"
         }
 
     - name: Verify that the used CA list is still the latest.


### PR DESCRIPTION
It is still applicable with the bundled json version, but our tests run after `bundle update` installed a newer version.