### PR TITLE
Use C99 in testgem to trigger issue with stdbool

### DIFF
--- a/test/helper/testgem/ext/extconf.rb
+++ b/test/helper/testgem/ext/extconf.rb
@@ -3,7 +3,7 @@
 require 'mkmf'
 require 'rbconfig'
 
-$CFLAGS << " -Wall -Wcast-qual -Wwrite-strings -Wconversion -Wmissing-noreturn -Winline"
+$CFLAGS << " -std=c99 -Wall -Wcast-qual -Wwrite-strings -Wconversion -Wmissing-noreturn -Winline"
 
 have_header('sys/types.h') || raise("have_header should find std header files")
 have_func('rb_thread_call_with_gvl') || raise("have_func should find libruby symbols")


### PR DESCRIPTION
This is to test for the following issue: https://github.com/oneclick/rubyinstaller2/issues/439

Error is:
```
In file included from C:/Ruby34-x64/include/ruby-3.4.0/ruby/defines.h:74,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/ruby.h:25,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby.h:38,
                 from conftest.c:1:
C:/msys64/ucrt64/include/stralign.h: In function 'ua_CharUpperW': C:/Ruby34-x64/include/ruby-3.4.0/ruby/backward/2/bool.h:31:15: error: 'true' undeclared (first use in this function)
   31 | # define TRUE true
      |               ^~~~
In file included from C:/msys64/ucrt64/include/windows.h:114,
                 from C:/msys64/ucrt64/include/winsock2.h:23,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/win32.h:36,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/internal/dosish.h:38,
                 from C:/Ruby34-x64/include/ruby-3.4.0/ruby/defines.h:78:
C:/msys64/ucrt64/include/stralign.h:1:1: note: 'true' is defined in header '<stdbool.h>'; this is probably fixable by adding '#include <stdbool.h>'
  +++ |+#include <stdbool.h>
    1 | /**
```