### PR TITLE
Fix MSYS2 detection

### DIFF
--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -77,7 +77,7 @@ module Build # Use for: Build, Runtime
             reg.each_key do |subkey|
               subreg = reg.open(subkey)
               begin
-                if subreg['DisplayName'] =~ /^MSYS2 / && File.directory?(il=subreg['InstallLocation'])
+                if subreg['DisplayName'] =~ /^MSYS2/ && File.directory?(il=subreg['InstallLocation'])
                   yield il
                 end
               rescue Encoding::InvalidByteSequenceError, Win32::Registry::Error


### PR DESCRIPTION
It seems #350 has gotten buried, but currently it's not possible to detect MSYS2 properly if installed system-wide due to this invalid regex.