### PR TITLE
CI: install innosetup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,15 @@ jobs:
         $(new-object net.webclient).DownloadFile("https://github.com/oneclick/rubyinstaller2/releases/download/RubyInstaller-3.0.7-1/rubyinstaller-3.0.7-1-x64.exe", "$pwd/ruby-setup.exe")
         cmd /c ruby-setup.exe /verysilent /currentuser
 
+    - name: Install Inno-Setup
+      shell: powershell
+      run: |
+        $InnoSetup = Join-Path ${env:PROGRAMFILES(X86)} -ChildPath 'Inno Setup 6\iscc.exe'
+        if (!(Test-Path $InnoSetup)) {
+          Invoke-WebRequest -Uri "https://jrsoftware.org/download.php/is.exe" -OutFile "D:\\is.exe"
+          Start-Process -FilePath "D:\\is.exe" -ArgumentList "/VERYSILENT", "/SUPPRESSMSGBOXES", "/NORESTART" -Wait
+        }
+
     - name: workaround signature issue on github actions
       shell: cmd
       run: C:\msys64\usr\bin\sed -i "/^SigLevel/ s/$/ DatabaseOptional/" /etc/pacman.conf


### PR DESCRIPTION
It was removed from Windows-2025 image.
See: actions/runner-images#12677

Commands taken from https://github.com/antgroup/hugescm/commit/376842ccf6c6a6999a14ff1163c87d192255bc12