### PR TITLE
Avoid update of net-http on ruby-3.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,5 @@ gemspec
 gem "octokit"
 gem "win32-process"
 gem "uri", "~> 0.13"
+
+gem "net-http", RUBY_VERSION =~ /^3\./ ? "~> 0.6.0" : nil


### PR DESCRIPTION
Because it fails in ruby-spec like so:

```
1)
Net::HTTP.post sends Content-Type: application/x-www-form-urlencoded by default FAILED
Expected "{\"Accept-Encoding\" => \"gzip;q=1.0,deflate;q=0.6,identity;q=0.3\", \"Accept\" => \"*/*\", \"User-Agent\" => \"Ruby\", \"Host\" => \"localhost:65525\", \"Content-Length\" => \"9\"}"
to include "\"Content-Type\" => \"application/x-www-form-urlencoded\""
D:/a/rubyinstaller2/rubyinstaller2/ruby/spec/ruby/library/net-http/http/post_spec.rb:30:in 'block (2 levels) in <top (required)>'
D:/a/rubyinstaller2/rubyinstaller2/ruby/spec/ruby/library/net-http/http/post_spec.rb:6:in '<top (required)>'

```