### PR TITLE
Extend c_rehash and README-SSL reg. new CA paths

### DIFF
--- a/resources/ssl/README-SSL.md
+++ b/resources/ssl/README-SSL.md
@@ -30,9 +30,11 @@ Addition of certificate to the Ruby default CA list
 ----------------------------------------------
 
 Additional certificates shall be stored in `<install-path>/ssl/certs/<yourfile>.pem` in pem format.
+This directory is checked by the builtin openssl gem for certificate verification.
+When the openssl gem is installed via source gem, then the directory `<msys2-dir>\<mingwarch>\etc\ssl\certs` is used instead.
 Each pem file may contain several certificates.
 The pem files must be activated for CA lookup by using a OpenSSL-hashed filename.
-There is a helper script in `<install-path>/ssl/certs/c_rehash.rb` to generate these hash files.
+There is a helper script in `<install-path>/ssl/certs/c_rehash.rb` to generate these hash files in both directories and in the `ca-bundle.crt` described below.
 Just double click `c_rehash.rb` to activate all pem files in the directory.
 
 Addition of certificates to the Devkit/MSYS2 CA list
@@ -41,7 +43,3 @@ MSYS2 has its own CA list which is maintained by [the MSYS2 project](http://msys
 This CA list is used by all MSYS2 tools like pacman, wget or curl.
 In order to add an additional CA certificate for MSYS2, you have to append it to `<msys2-dir>\usr\ssl\certs\ca-bundle.crt` in PEM format.
 In a default Rubyinstaller-Devkit-2.5-x64 setup this file is here: `c:\Ruby25-x64\msys64\usr\ssl\certs\ca-bundle.crt`
-
-Please also note, that pacman's builtin HTTP client doesn't work well with proxies.
-You probably have to enable `wget` in `<msys2-dir>\etc\pacman.conf`.
-It also respects `http_proxy` and `https_proxy` environment variables set in Windows system settings.


### PR DESCRIPTION
RubyInstaller-3.4 changed how the builtin libssl library is used. It is only used together with the builtin openssl gem. The buildin openssl gem has it's own CA certificates path.

When a source gem is linked to libssl, then the MSYS2 provided libssl and it's CA certificates are used. Moreover the MSYS2 tools like pacman or curl use a separate file named `ca-bundle.crt`.

All three diretories are now filled by the `c_rehash.rb` helper script now. And the `README-SSL` describes the paths.