### PR TITLE
Tighten environment variable display when `ridk enable`

### DIFF
--- a/resources/files/ridk.cmd
+++ b/resources/files/ridk.cmd
@@ -26,9 +26,8 @@ shift
 @exit /b %ERRORLEVEL%
 
 :setvars
-@echo on
-@for /f "delims=" %%x in ('"%~dp0ruby" --disable-gems -x '%~f0' %*') do set "%%x"
-@exit /b %ERRORLEVEL%
+for /f "delims=" %%x in ('"%~dp0ruby" --disable-gems -x '%~f0' %*') do set "%%x" && echo %%x
+exit /b %ERRORLEVEL%
 
 :use
 "%~dp0../ridk_use/ridk.cmd" %*


### PR DESCRIPTION
before
```
C:\>ridk enable

C:\>set "RI_DEVKIT=C:\msys64"

C:\>set "MSYSTEM=UCRT64"

C:\>set "PKG_CONFIG_PATH=/ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig"

C:\>set "ACLOCAL_PATH=/ucrt64/share/aclocal:/usr/share/aclocal"

C:\>set "MANPATH=/ucrt64/share/man"

C:\>set "MINGW_PACKAGE_PREFIX=mingw-w64-ucrt-x86_64"

C:\>set "MSYSTEM_PREFIX=/ucrt64"

C:\>set "MSYSTEM_CARCH=x86_64"

C:\>set "MSYSTEM_CHOST=x86_64-w64-mingw32"

C:\>set "MINGW_CHOST=x86_64-w64-mingw32"

C:\>set "MINGW_PREFIX=/ucrt64"

C:\>set "LANG=ja_JP.UTF-8"

C:\>
```
after
```
C:\>r:\ridk enable
RI_DEVKIT=C:\msys64
MSYSTEM=UCRT64
PKG_CONFIG_PATH=/ucrt64/lib/pkgconfig:/ucrt64/share/pkgconfig
ACLOCAL_PATH=/ucrt64/share/aclocal:/usr/share/aclocal
MANPATH=/ucrt64/share/man
MINGW_PACKAGE_PREFIX=mingw-w64-ucrt-x86_64
MSYSTEM_PREFIX=/ucrt64
MSYSTEM_CARCH=x86_64
MSYSTEM_CHOST=x86_64-w64-mingw32
MINGW_CHOST=x86_64-w64-mingw32
MINGW_PREFIX=/ucrt64
LANG=ja_JP.UTF-8
C:\>
```