### PR TITLE
preliminary support for clang64

### DIFF
--- a/lib/ruby_installer/build/components/03_dev_tools.rb
+++ b/lib/ruby_installer/build/components/03_dev_tools.rb
@@ -52,6 +52,7 @@ class DevTools < Base
     'mingw32' => PACKAGES_MINGW32,
     'mingw64' => PACKAGES_MINGW64,
     'ucrt64' => PACKAGES_MINGW64,
+    'clang64' => PACKAGES_MINGW64,
     'clangarm64' => PACKAGES_MINGW64,
   }
 

--- a/lib/ruby_installer/build/msys2_installation.rb
+++ b/lib/ruby_installer/build/msys2_installation.rb
@@ -35,6 +35,7 @@ module Build # Use for: Build, Runtime
           when 'mingw32' then "mingw-w64-i686"
           when 'mingw64' then "mingw-w64-x86_64"
           when 'ucrt64'  then "mingw-w64-ucrt-x86_64"
+          when 'clang64'  then "mingw-w64-clang-x86_64"
           when 'clangarm64' then "mingw-w64-clang-aarch64"
           else raise "unknown mingwarch #{@mingwarch.inspect}"
         end
@@ -184,6 +185,12 @@ module Build # Use for: Build, Runtime
           vars['MINGW_PREFIX'] = vars['MSYSTEM_PREFIX']
         when 'ucrt64'
           vars['MSYSTEM_PREFIX'] = '/ucrt64'
+          vars['MSYSTEM_CARCH'] = 'x86_64'
+          vars['MSYSTEM_CHOST'] = 'x86_64-w64-mingw32'
+          vars['MINGW_CHOST'] = vars['MSYSTEM_CHOST']
+          vars['MINGW_PREFIX'] = vars['MSYSTEM_PREFIX']
+        when 'clang64'
+          vars['MSYSTEM_PREFIX'] = '/clang64'
           vars['MSYSTEM_CARCH'] = 'x86_64'
           vars['MSYSTEM_CHOST'] = 'x86_64-w64-mingw32'
           vars['MINGW_CHOST'] = vars['MSYSTEM_CHOST']

--- a/lib/ruby_installer/runtime/ridk.rb
+++ b/lib/ruby_installer/runtime/ridk.rb
@@ -54,7 +54,10 @@ LOGO = %q{
       DEFAULT_COMPONENTS = %w[1 3]
 
       def install(args)
-        ci = ComponentsInstaller.new
+        if args && %w[ucrt64 mingw64 mingw32 clang64 clangarm64].include?(args[0])
+          msys  = Msys2Installation.new(mingwarch: args.shift)
+        end
+        ci = ComponentsInstaller.new(msys:)
         inst_defaults = DEFAULT_COMPONENTS
 
         if args.empty?


### PR DESCRIPTION
This is not intended to implement a clang64 version of rubyinstaller, but rather to set up a clang64 development environment.

`ridk install` now accepts mingwarch, e.g `ridk install clang64 3`.
after that, we can play with `ridk enable clang64`.
this makes it easier for us to try developing ruby on clang64.