### PR TITLE
Add the missing `rdbg` executable

### DIFF
--- a/recipes/sandbox/rubyinstaller-3.1.7.files
+++ b/recipes/sandbox/rubyinstaller-3.1.7.files
@@ -14,6 +14,8 @@ bin/rake
 bin/rake.bat
 bin/rbs
 bin/rbs.bat
+bin/rdbg
+bin/rdbg.bat
 bin/rdoc
 bin/rdoc.bat
 bin/ri

--- a/recipes/sandbox/rubyinstaller-3.2.10.files
+++ b/recipes/sandbox/rubyinstaller-3.2.10.files
@@ -14,6 +14,8 @@ bin/rake
 bin/rake.bat
 bin/rbs
 bin/rbs.bat
+bin/rdbg
+bin/rdbg.bat
 bin/rdoc
 bin/rdoc.bat
 bin/ri

--- a/recipes/sandbox/rubyinstaller-3.3.10.files
+++ b/recipes/sandbox/rubyinstaller-3.3.10.files
@@ -14,6 +14,8 @@ bin/rake
 bin/rake.bat
 bin/rbs
 bin/rbs.bat
+bin/rdbg
+bin/rdbg.bat
 bin/rdoc
 bin/rdoc.bat
 bin/ri

--- a/recipes/sandbox/rubyinstaller-3.4.8.files
+++ b/recipes/sandbox/rubyinstaller-3.4.8.files
@@ -14,6 +14,8 @@ bin/rake
 bin/rake.bat
 bin/rbs
 bin/rbs.bat
+bin/rdbg
+bin/rdbg.bat
 bin/rdoc
 bin/rdoc.bat
 bin/ri

--- a/recipes/sandbox/rubyinstaller-4.0.1.files
+++ b/recipes/sandbox/rubyinstaller-4.0.1.files
@@ -14,6 +14,8 @@ bin/rake
 bin/rake.bat
 bin/rbs
 bin/rbs.bat
+bin/rdbg
+bin/rdbg.bat
 bin/rdoc
 bin/rdoc.bat
 bin/ri

--- a/recipes/sandbox/rubyinstaller-head.files
+++ b/recipes/sandbox/rubyinstaller-head.files
@@ -14,6 +14,8 @@ bin/rake
 bin/rake.bat
 bin/rbs
 bin/rbs.bat
+bin/rdbg
+bin/rdbg.bat
 bin/rdoc
 bin/rdoc.bat
 bin/ri


### PR DESCRIPTION
The `debug` gem is a "bundled gem" since Ruby 3.1.0, its executable `rdbg` is missing.

I'm not sure if it's necessary to build a new package release for each version for just a so small fix. So I don't modify `packages/ri/Rakefile`.